### PR TITLE
Release version 0.3.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,24 +15,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - {os: ubuntu-20.04, crystal: 1.0.0}
           - {os: ubuntu-20.04, crystal: 0.36.1}
+          - {os: ubuntu-18.04, crystal: 1.0.0}
           - {os: ubuntu-18.04, crystal: 0.36.1}
-          - {os: ubuntu-20.04, crystal: 0.36.0}
-          - {os: ubuntu-18.04, crystal: 0.36.0}
-          - {os: ubuntu-20.04, crystal: 0.35.1}
-          - {os: ubuntu-18.04, crystal: 0.35.1}
-          - {os: ubuntu-20.04, crystal: 0.35.0}
-          - {os: ubuntu-18.04, crystal: 0.35.0}
-          - {os: ubuntu-20.04, crystal: 0.34.0}
-          - {os: ubuntu-18.04, crystal: 0.34.0}
-          - {os: ubuntu-20.04, crystal: 0.33.0}
-          - {os: ubuntu-18.04, crystal: 0.33.0}
-          - {os: ubuntu-20.04, crystal: 0.32.1}
-          - {os: ubuntu-18.04, crystal: 0.32.1}
-          - {os: ubuntu-20.04, crystal: 0.32.0}
-          - {os: ubuntu-18.04, crystal: 0.32.0}
-          - {os: ubuntu-20.04, crystal: 0.31.1}
-          - {os: ubuntu-18.04, crystal: 0.31.1}
+          - {os: macOS-latest, crystal: 1.0.0}
           - {os: macOS-latest, crystal: 0.36.1}
     runs-on: ${{matrix.os}}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.3.0] - 2021-03-29
+- Bump Crystal version to 1.0.0.
+- Drup Crystal support under version 0.36.1.
+
 ## [0.2.0] - 2021-03-12
 - Add support of the Crystal version 36.1.
 - Add issues and pull requests templates.

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ This shard is a port of the [pdf-forms](https://github.com/jkraemer/pdf-forms) R
 
 ## Important Information
 
-This shard has been tested and works great with PDFtk 3.0, Ubuntu 18.04, Ubuntu 20.04 and Crystal 0.31.1 - 0.36.1.
+This shard has been tested and works great with PDFtk 3.0, Ubuntu 18.04, Ubuntu 20.04 and Crystal 0.36.1 - 1.0.0.
 
-Also it tested against MacOS latest and Crystal 0.36.1
+Also it tested against MacOS latest and Crystal 0.36.1 - 1.0.0.
 
 The installation of the PDFtk 3.0 is recommended for normal work.
 
@@ -43,7 +43,7 @@ Shard can work with PDFtk 2.0 if PDFtk has access to the **/tmp** diretcory.
    dependencies:
      pdf-forms.cr:
        github: unrooty/pdf-forms.cr
-       version: 0.2.0 # optional
+       version: 0.3.0 # optional
    ```
 
 -  Run 

--- a/shard.yml
+++ b/shard.yml
@@ -7,8 +7,8 @@ authors:
 dependencies:
   minitest:
     github: ysbaddaden/minitest.cr
-    version: 0.5.1
+    version: '>= 1.0.1'
 
-crystal: 0.36.1
+crystal: 1.0.0
 
 license: MIT


### PR DESCRIPTION
## Overview
This is the release of the version 0.3.0.

## Details
- Bump Crystal version to 1.0.0.
- Drop Crystal support under version 0.36.1.
- Bump `minitest.cr` to `1.0.1` version.
