### PR TITLE
[Release] Version 1.1.0 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,30 +15,33 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { os: ubuntu-20.04, crystal: 1.6.1 }
+          - { os: ubuntu-20.04, crystal: 1.12.1 }
+          - { os: ubuntu-20.04, crystal: 1.11.2 }
+          - { os: ubuntu-20.04, crystal: 1.10.1 }
+          - { os: ubuntu-20.04, crystal: 1.9.2 }
+          - { os: ubuntu-20.04, crystal: 1.8.2 }
+          - { os: ubuntu-20.04, crystal: 1.7.3 }
+          - { os: ubuntu-20.04, crystal: 1.6.2 }
           - { os: ubuntu-20.04, crystal: 1.5.1 }
           - { os: ubuntu-20.04, crystal: 1.4.1 }
-          - { os: ubuntu-20.04, crystal: 1.3.2 }
-          - { os: ubuntu-20.04, crystal: 1.2.1 }
-          - { os: ubuntu-20.04, crystal: 1.1.1 }
-          - { os: ubuntu-20.04, crystal: 1.0.0 }
-          - { os: ubuntu-20.04, crystal: 0.36.1 }
-          - { os: ubuntu-22.04, crystal: 1.6.1 }
+          - { os: ubuntu-22.04, crystal: 1.12.1 }
+          - { os: ubuntu-22.04, crystal: 1.11.2 }
+          - { os: ubuntu-22.04, crystal: 1.10.1 }
+          - { os: ubuntu-22.04, crystal: 1.9.2 }
+          - { os: ubuntu-22.04, crystal: 1.8.2 }
+          - { os: ubuntu-22.04, crystal: 1.7.3 }
+          - { os: ubuntu-22.04, crystal: 1.6.2 }
           - { os: ubuntu-22.04, crystal: 1.5.1 }
           - { os: ubuntu-22.04, crystal: 1.4.1 }
-          - { os: ubuntu-22.04, crystal: 1.3.2 }
-          - { os: ubuntu-22.04, crystal: 1.2.1 }
-          - { os: ubuntu-22.04, crystal: 1.1.1 }
-          - { os: ubuntu-22.04, crystal: 1.0.0 }
-          - { os: ubuntu-22.04, crystal: 0.36.1 }
-          - { os: macOS-latest, crystal: 1.6.1 }
+          - { os: macOS-latest, crystal: 1.12.1 }
+          - { os: macOS-latest, crystal: 1.11.2 }
+          - { os: macOS-latest, crystal: 1.10.1 }
+          - { os: macOS-latest, crystal: 1.9.2 }
+          - { os: macOS-latest, crystal: 1.8.2 }
+          - { os: macOS-latest, crystal: 1.7.3 }
+          - { os: macOS-latest, crystal: 1.6.2 }
           - { os: macOS-latest, crystal: 1.5.1 }
           - { os: macOS-latest, crystal: 1.4.1 }
-          - { os: macOS-latest, crystal: 1.3.2 }
-          - { os: macOS-latest, crystal: 1.2.1 }
-          - { os: macOS-latest, crystal: 1.1.1 }
-          - { os: macOS-latest, crystal: 1.0.0 }
-          - { os: macOS-latest, crystal: 0.36.1 }
     runs-on: ${{matrix.os}}
     steps:
       - name: 'Prepare Ubuntu 22.04 ENV'
@@ -50,23 +53,17 @@ jobs:
         if: matrix.os == 'ubuntu-20.04'
         run: |
           sudo apt install pdftk
-      
-      - name: 'Prepare Ubuntu 18.04 ENV'
-        if: matrix.os == 'ubuntu-18.04'
-        run: |
-          wget http://launchpadlibrarian.net/475142792/pdftk-java_3.0.9-1_all.deb
-          sudo apt install default-jre-headless libcommons-lang3-java libbcprov-java
-          sudo dpkg -i pdftk-java_3.0.9-1_all.deb
+
       - name: 'Prepare MacOS ENV'
         if: matrix.os == 'macOS-latest'
         run: |
           brew install pdftk-java
 
-      - uses: oprypin/install-crystal@v1
+      - uses: crystal-lang/install-crystal@v1
         with:
           crystal: ${{matrix.crystal}}
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Test
         run: |

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-crystal 1.6.1
+crystal 1.12.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.1.0] - 2024-04-24
+- Improve test matrix to test against Ubuntu 22.04 and Crystal version 1.7.x, 1.8.x, 1.9.x, 1.10.x, 1.11.x, 1.12.x.
+- Use Crystal `1.12.1` in `.tools-versions` as latest Crystal version.
+- Bump shard version to `v1.1.0` due to old Crystal versions drop.
+- Update `actions/checkhout` to `v4` to avoid unsupported packages versions usage.
+
 ## [1.0.0] - 2022-10-24
 - Improve test matrix to test against Ubuntu 22.04 and Crystal version 1.4.1, 1.5.1, 1.6.1.
 - Use Crystal `1.6.1` in `.tools-versions` as latest Crystal version.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019-2022 Vladislav Volkov
+Copyright (c) 2019-2024 Vladislav Volkov
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ This shard is a port of the [pdf-forms](https://github.com/jkraemer/pdf-forms) R
 
 ## Important Information
 
-This shard has been tested and works great with PDFtk 3.0, Ubuntu 18.04, Ubuntu 20.04 and Crystal 0.36.1 - 1.0.0.
+This shard has been tested and works great with PDFtk 3.0, Ubuntu 20.04 and Crystal 1.1.1 - 1.12.1.
 
-Also it tested against MacOS latest and Crystal 0.36.1 - 1.0.0.
+Also it tested against MacOS latest and Crystal 1.1.1 - 1.12.1.
 
 The installation of the PDFtk 3.0 is recommended for normal work.
 
@@ -18,30 +18,20 @@ Shard can work with PDFtk 2.0 if PDFtk has access to the **/tmp** diretcory.
 
 ## Crystal and OS support
 
-You can see test matrix with OS and Crystal version support using the following link:
+See [older releases](https://github.com/unrooty/pdf-forms.cr/releases) for the support of the older Crystal versions and OS.
 
-https://github.com/unrooty/pdf-forms.cr/actions/workflows/test.yml
+You can see [test matrix](https://github.com/unrooty/pdf-forms.cr/actions/workflows/test.yml) with OS and Crystal version supports.
 
 ## Installation
-
--  Install PDFtk (Ubuntu 18.04 only)
-
-```bash
-  wget http://launchpadlibrarian.net/475142792/pdftk-java_3.0.9-1_all.deb
-  sudo apt install default-jre-headless libcommons-lang3-java libbcprov-java
-  sudo dpkg -i pdftk-java_3.0.9-1_all.deb
-```
-
-- Install PDFtk (Ubuntu 20.04 only)
-
-```bash
-  sudo apt install pdftk
-```
-
-- Install PDFtk (MacOS latest only)
-```bash
-  brew install pdftk-java
-```
+- Install PDFtk
+  - Ubuntu 20.04 / Ununtu 22.04
+    ```bash
+      sudo apt install pdftk
+    ```
+  - MacOS latest
+    ```bash
+      brew install pdftk-java
+    ```
 
 - Add the dependency to your `shard.yml`:
 
@@ -49,7 +39,7 @@ https://github.com/unrooty/pdf-forms.cr/actions/workflows/test.yml
    dependencies:
      pdf-forms.cr:
        github: unrooty/pdf-forms.cr
-       version: 0.3.0 # optional
+       version: 1.1.0 # optional
    ```
 
 -  Run 
@@ -62,7 +52,7 @@ https://github.com/unrooty/pdf-forms.cr/actions/workflows/test.yml
 ### FDF/XFdf creation
 
 ```ruby
-require 'pdf_forms'
+require "pdf_forms"
 
 fdf = PdfForms::Fdf.new("key" => "value", "other_key" => "other value")
 
@@ -78,7 +68,7 @@ To generate XFDF instead of FDF instantiate `PdfForms::XFdf` instead of `PdfForm
 ### Query form fields and fill out PDF forms with pdftk
 
 ```ruby
-require 'pdf_forms'
+require "pdf_forms"
 
 # adjust the pdftk path to suit your pdftk installation
 # add "data_format" => "xfdf" option to generate XFDF instead of FDF when
@@ -118,7 +108,7 @@ If value has not been stored, most of the time there is a problem with filling o
 
 ## Testing
 
-Currencly shard uses [minitest.cr](https://github.com/ysbaddaden/minitest.cr).
+Currently shard uses [minitest.cr](https://github.com/ysbaddaden/minitest.cr).
 
 To run specs use `crystal run ./spec/*_test.cr` command.
 

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: pdf-forms
-version: 1.0.0
+version: 1.1.0
 
 authors:
   - Vladislav Volkov <volcharneverfall1996@gmail.com>
@@ -7,8 +7,8 @@ authors:
 development_dependencies:
   minitest:
     github: ysbaddaden/minitest.cr
-    version: '>= 1.0.1'
+    version: '>= 1.1.0'
 
-crystal: '>= 0.36.1'
+crystal: '>= 1.1.1'
 
 license: MIT


### PR DESCRIPTION
## Overview
Improve test matrix with Crystal versions and release new version

## Details
- Improve test matrix with latest Crystal versions.
- Drop old Crystal versions support.
- Drop Ubuntu 18.04 docs.
- Improve dependencies and docs according changes.
- Bump shard to `v1.1.0`
